### PR TITLE
Add SingleChildScrollView to ConfigurationBar

### DIFF
--- a/lib/src/widget_stage.dart
+++ b/lib/src/widget_stage.dart
@@ -46,8 +46,8 @@ class _WidgetStageState extends State<WidgetStage> {
                 SizedBox(
                   width: 300,
                   child: ConfigurationBar(
-                    fields: _stageController.selectedWidget?.fieldConfigurators.map((e) {
-                          return e.builder(context);
+                    fields: _stageController.selectedWidget?.fieldConfigurators.map((configurator) {
+                          return configurator.builder(context);
                         }).toList() ??
                         [],
                   ),
@@ -93,14 +93,14 @@ class ConfigurationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
       child: Column(
         children: fields.map(
-          (e) {
+          (field) {
             return Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
-              child: e,
+              child: field,
             );
           },
         ).toList(),


### PR DESCRIPTION
This PR makes the ConfigurationBar scrollable which prevents an overflow in case of many field configurators.


https://user-images.githubusercontent.com/77627178/225784220-3eb688b8-03ab-44e9-b327-e6accaa66f5a.mov

