### PR TITLE
Refine configuration bar

### DIFF
--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -43,7 +43,7 @@ class ColorFieldConfiguratorNullable extends FieldConfigurator<Color?> {
   }
 }
 
-class ColorPickerField extends StatelessWidget {
+class ColorPickerField extends StatefulWidget {
   const ColorPickerField({
     super.key,
     required this.color,
@@ -58,13 +58,26 @@ class ColorPickerField extends StatelessWidget {
   final bool isNullable;
 
   @override
+  State<ColorPickerField> createState() => _ColorPickerFieldState();
+}
+
+class _ColorPickerFieldState extends State<ColorPickerField> {
+  Color? _initialColor;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialColor = widget.color;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return FieldConfiguratorWidget(
       onNullTapped: () {
-        onChanged(null);
+        widget.onChanged(null);
       },
-      name: name,
-      isNullable: isNullable,
+      name: widget.name,
+      isNullable: widget.isNullable,
       child: GestureDetector(
         onTap: () async {
           showDialog(
@@ -74,11 +87,18 @@ class ColorPickerField extends StatelessWidget {
                 title: const Text('Pick a color!'),
                 content: SingleChildScrollView(
                   child: ColorPicker(
-                    pickerColor: color ?? Colors.transparent,
-                    onColorChanged: onChanged,
+                    pickerColor: widget.color ?? Colors.transparent,
+                    onColorChanged: widget.onChanged,
                   ),
                 ),
                 actions: <Widget>[
+                  ElevatedButton(
+                    child: const Text('Cancel'),
+                    onPressed: () {
+                      widget.onChanged.call(_initialColor);
+                      Navigator.of(context).pop();
+                    },
+                  ),
                   ElevatedButton(
                     child: const Text('Accept'),
                     onPressed: () {
@@ -94,9 +114,9 @@ class ColorPickerField extends StatelessWidget {
           height: 48,
           width: 48,
           decoration: BoxDecoration(
-            color: color,
+            color: widget.color,
             borderRadius: BorderRadius.circular(8),
-            border: color == Colors.transparent ? Border.all(color: Colors.grey[600]!) : null,
+            border: widget.color == Colors.transparent ? Border.all(color: Colors.grey[600]!) : null,
           ),
         ),
       ),

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -72,6 +72,11 @@ class _ColorPickerFieldState extends State<ColorPickerField> {
 
   @override
   Widget build(BuildContext context) {
+    final border = () {
+      if (widget.color == Colors.transparent || widget.color == null) {
+        return Border.all(color: Colors.grey[600]!);
+      }
+    }();
     return FieldConfiguratorWidget(
       onNullTapped: () {
         widget.onChanged(null);
@@ -116,7 +121,7 @@ class _ColorPickerFieldState extends State<ColorPickerField> {
           decoration: BoxDecoration(
             color: widget.color,
             borderRadius: BorderRadius.circular(8),
-            border: widget.color == Colors.transparent ? Border.all(color: Colors.grey[600]!) : null,
+            border: border,
           ),
         ),
       ),

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -96,6 +96,7 @@ class ColorPickerField extends StatelessWidget {
           decoration: BoxDecoration(
             color: color,
             borderRadius: BorderRadius.circular(8),
+            border: color == Colors.transparent ? Border.all(color: Colors.grey[600]!) : null,
           ),
         ),
       ),

--- a/lib/src/field_configurators/field_configurator_widget.dart
+++ b/lib/src/field_configurators/field_configurator_widget.dart
@@ -17,24 +17,25 @@ class FieldConfiguratorWidget<T> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
+        Expanded(
+          child: Text('$name:'),
+        ),
         Expanded(
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text('$name:'),
-              if (isNullable)
+              Expanded(child: child),
+              if (isNullable) ...[
+                const SizedBox(width: 4.0),
                 TextButton(
                   onPressed: onNullTapped,
                   child: const Text('null'),
                 ),
+              ]
             ],
           ),
-        ),
-        Expanded(
-          child: child,
         ),
       ],
     );

--- a/lib/src/field_configurators/field_configurator_widget.dart
+++ b/lib/src/field_configurators/field_configurator_widget.dart
@@ -26,14 +26,14 @@ class FieldConfiguratorWidget<T> extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Expanded(child: child),
               if (isNullable) ...[
                 const SizedBox(width: 4.0),
                 TextButton(
                   onPressed: onNullTapped,
                   child: const Text('null'),
                 ),
-              ]
+              ],
+              Expanded(child: child),
             ],
           ),
         ),


### PR DESCRIPTION
This PR makes the following changes:

1. Adjusts the layout of the "null" button in the configuration bar to make it look more aligned and also less prone to overflow for longer widget names

2. Adds a border around the color picker widget for when its color is transparent
 
3. Adds "cancel" action to the color picker which resets the color to its initial value
<img width="401" alt="Bildschirmfoto 2023-03-22 um 02 01 13" src="https://user-images.githubusercontent.com/77627178/226775461-dea8b211-b809-4874-9d7e-74e29fd6e415.png">
<img width="691" alt="Bildschirmfoto 2023-03-22 um 02 05 02" src="https://user-images.githubusercontent.com/77627178/226775464-d6b90411-60ed-44d4-a538-49ad05a476b8.png">
 