### PR TITLE
Upgrade ColorPickerField and add stage size setter

### DIFF
--- a/example/lib/stage_data/my_other_widget_stage.dart
+++ b/example/lib/stage_data/my_other_widget_stage.dart
@@ -2,7 +2,7 @@ import 'package:example/widgets/my_other_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:widget_stage/widget_stage.dart';
 
-class MyOtherWidgetStageData implements WidgetStageData {
+class MyOtherWidgetStageData extends WidgetStageData {
   MyOtherWidgetStageData() : _text = StringFieldConfigurator(value: 'MyOtherWidget', name: 'text');
 
   final StringFieldConfigurator _text;

--- a/example/lib/stage_data/my_widget_stage.dart
+++ b/example/lib/stage_data/my_widget_stage.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:widget_stage/widget_stage.dart';
 
 /// Defines everything you need to put it on the stage.
-class MyWidgetStageData implements WidgetStageData {
+class MyWidgetStageData extends WidgetStageData {
   MyWidgetStageData()
       : _color = ColorFieldConfiguratorNullable(value: null, name: 'color'),
         _text = StringFieldConfigurator(value: "My text", name: 'text'),
@@ -12,6 +12,9 @@ class MyWidgetStageData implements WidgetStageData {
 
   @override
   String get name => 'MyWidget';
+
+  @override
+  Size get stageSize => const Size(200, 200);
 
   final ColorFieldConfiguratorNullable _color;
   final StringFieldConfigurator _text;

--- a/example/lib/stage_data/my_widget_stage.dart
+++ b/example/lib/stage_data/my_widget_stage.dart
@@ -5,7 +5,7 @@ import 'package:widget_stage/widget_stage.dart';
 /// Defines everything you need to put it on the stage.
 class MyWidgetStageData implements WidgetStageData {
   MyWidgetStageData()
-      : _color = ColorFieldConfigurator(value: Colors.transparent, name: 'color'),
+      : _color = ColorFieldConfiguratorNullable(value: null, name: 'color'),
         _text = StringFieldConfigurator(value: "My text", name: 'text'),
         _nullableBool = BoolFieldConfiguratorNullable(value: false, name: 'nullableBool'),
         _borderRadius = DoubleFieldConfiguratorNullable(value: 4, name: 'borderRadius');
@@ -13,7 +13,7 @@ class MyWidgetStageData implements WidgetStageData {
   @override
   String get name => 'MyWidget';
 
-  final ColorFieldConfigurator _color;
+  final ColorFieldConfiguratorNullable _color;
   final StringFieldConfigurator _text;
   final BoolFieldConfiguratorNullable _nullableBool;
   final DoubleFieldConfiguratorNullable _borderRadius;

--- a/example/lib/widgets/my_widget.dart
+++ b/example/lib/widgets/my_widget.dart
@@ -9,7 +9,7 @@ class MyWidget extends StatelessWidget {
     this.borderRadius = 8,
   });
 
-  final Color color;
+  final Color? color;
   final double? borderRadius;
   final String text;
   final bool? isTrue;
@@ -18,7 +18,7 @@ class MyWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: color,
+        color: color ?? Colors.transparent,
         borderRadius: BorderRadius.circular(borderRadius ?? 0),
       ),
       child: Container(

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -31,10 +31,7 @@ class ColorFieldConfiguratorNullable extends FieldConfigurator<Color?> {
   Widget build(BuildContext context) {
     return ColorConfigurationWidget(
       value: value,
-      updateValue: (Color? color) {
-        value = color;
-        notifyListeners();
-      },
+      updateValue: updateValue,
     );
   }
 }
@@ -55,11 +52,6 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final border = () {
-      if (color == Colors.transparent || color == null) {
-        return Border.all(color: Colors.grey[600]!);
-      }
-    }();
     return GestureDetector(
       onTap: () async {
         showDialog(
@@ -69,7 +61,7 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
               title: const Text('Pick a color!'),
               content: SingleChildScrollView(
                 child: ColorPicker(
-                  pickerColor: widget.value ?? Colors.transparent,
+                  pickerColor: widget.value ?? Colors.white,
                   onColorChanged: (newColor) {
                     color = newColor;
                   },
@@ -95,14 +87,62 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
         );
       },
       child: Container(
-        height: 48,
-        width: 48,
-        decoration: BoxDecoration(
-          color: widget.value,
-          borderRadius: BorderRadius.circular(8),
-          border: border,
-        ),
-      ),
+          height: 48,
+          width: 48,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: CustomPaint(
+              painter: ChessBoardPainter(
+                boxSize: 8,
+                color: widget.value,
+                offset: Offset(-4, -8),
+              ),
+            ),
+          )),
     );
+  }
+}
+
+class ChessBoardPainter extends CustomPainter {
+  const ChessBoardPainter({
+    this.boxSize = 20,
+    this.offset = Offset.zero,
+    this.color,
+  });
+
+  final double boxSize;
+  final Offset offset;
+  final Color? color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    print(color);
+    final paint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.fill;
+
+    for (int vertical = 0; vertical < (size.height / boxSize) + 1; vertical++) {
+      for (int horizontal = 0; horizontal < (size.width / boxSize) + 1; horizontal = horizontal + 2) {
+        canvas.drawRect(
+          Rect.fromLTWH(
+            (horizontal.toDouble() * boxSize + boxSize * (vertical % 2)) + offset.dx,
+            (vertical.toDouble() * boxSize) + offset.dy,
+            boxSize,
+            boxSize,
+          ),
+          paint,
+        );
+      }
+    }
+    canvas.drawColor(color ?? Colors.grey, BlendMode.hue);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    print('should repaint');
+    return true;
   }
 }

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -86,50 +86,61 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
           },
         );
       },
-      child: Container(
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
           height: 48,
           width: 48,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
+          foregroundDecoration: BoxDecoration(
+            // The actual color drawn over the chessboard pattern
+            color: widget.value,
           ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: CustomPaint(
-              painter: ChessBoardPainter(
-                boxSize: 8,
-                color: widget.value,
-                offset: Offset(-4, -8),
-              ),
+          // The chessboard pattern
+          child: const CustomPaint(
+            foregroundPainter: ChessBoardPainter(
+              boxSize: 8,
+              // The color of the chessboard pattern
+              color: Colors.grey,
             ),
-          )),
+            child: ColoredBox(
+              // Background of the chessboard pattern
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
 
 class ChessBoardPainter extends CustomPainter {
   const ChessBoardPainter({
+    required this.color,
     this.boxSize = 20,
-    this.offset = Offset.zero,
-    this.color,
   });
 
   final double boxSize;
-  final Offset offset;
-  final Color? color;
+  final Color color;
 
   @override
   void paint(Canvas canvas, Size size) {
-    print(color);
     final paint = Paint()
-      ..color = Colors.white
+      ..color = Colors.grey
       ..style = PaintingStyle.fill;
 
-    for (int vertical = 0; vertical < (size.height / boxSize) + 1; vertical++) {
-      for (int horizontal = 0; horizontal < (size.width / boxSize) + 1; horizontal = horizontal + 2) {
+    final maxVerticalBoxes = size.height / boxSize + 1;
+    final maxHorizontalBoxes = size.width / boxSize + 1;
+
+    for (int verticalBoxIndex = 0; verticalBoxIndex < maxVerticalBoxes; verticalBoxIndex++) {
+      for (int horizontalBoxIndex = 0;
+          horizontalBoxIndex < maxHorizontalBoxes;
+          horizontalBoxIndex = horizontalBoxIndex + 2) {
+        // Add a boxSize offset for every second row
+        final offset = (verticalBoxIndex % 2) * boxSize;
         canvas.drawRect(
           Rect.fromLTWH(
-            (horizontal.toDouble() * boxSize + boxSize * (vertical % 2)) + offset.dx,
-            (vertical.toDouble() * boxSize) + offset.dy,
+            horizontalBoxIndex * boxSize + offset,
+            verticalBoxIndex * boxSize,
             boxSize,
             boxSize,
           ),
@@ -137,12 +148,10 @@ class ChessBoardPainter extends CustomPainter {
         );
       }
     }
-    canvas.drawColor(color ?? Colors.grey, BlendMode.hue);
   }
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    print('should repaint');
     return true;
   }
 }

--- a/lib/src/flexible_stage.dart
+++ b/lib/src/flexible_stage.dart
@@ -121,7 +121,11 @@ class _ResizableWidgetState extends State<FlexibleStage> {
                     child: Container(
                       height: height,
                       width: width,
-                      color: Colors.black26,
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: Colors.black.withOpacity(0.3),
+                        ),
+                      ),
                       child: widget.child,
                     ),
                   ),

--- a/lib/src/flexible_stage.dart
+++ b/lib/src/flexible_stage.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:widget_stage/src/widget_stage.dart';
 
 class FlexibleStage extends StatefulWidget {
   const FlexibleStage({
     super.key,
     required this.child,
+    required this.stageController,
   });
 
   final Widget child;
+  final StageController stageController;
 
   @override
   _ResizableWidgetState createState() => _ResizableWidgetState();
@@ -15,8 +18,8 @@ class FlexibleStage extends StatefulWidget {
 const ballDiameter = 22.0;
 
 class _ResizableWidgetState extends State<FlexibleStage> {
-  double height = 600;
-  double width = 800;
+  late double height = 600;
+  late double width = 800;
 
   double top = 50;
   double left = 50;
@@ -40,6 +43,14 @@ class _ResizableWidgetState extends State<FlexibleStage> {
   @override
   void initState() {
     super.initState();
+    widget.stageController.addListener(() {
+      if (widget.stageController.selectedWidget != null) {
+        setState(() {
+          height = widget.stageController.selectedWidget!.stageSize!.height;
+          width = widget.stageController.selectedWidget!.stageSize!.width;
+        });
+      }
+    });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {
         top = currentConstraints!.maxHeight / 2 - height / 2;

--- a/lib/src/flexible_stage.dart
+++ b/lib/src/flexible_stage.dart
@@ -48,14 +48,19 @@ class _ResizableWidgetState extends State<FlexibleStage> {
         setState(() {
           height = widget.stageController.selectedWidget!.stageSize!.height;
           width = widget.stageController.selectedWidget!.stageSize!.width;
+          centerStage();
         });
       }
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        top = currentConstraints!.maxHeight / 2 - height / 2;
-        left = currentConstraints!.maxWidth / 2 - width / 2;
-      });
+      centerStage();
+    });
+  }
+
+  void centerStage() {
+    setState(() {
+      top = currentConstraints!.maxHeight / 2 - height / 2;
+      left = currentConstraints!.maxWidth / 2 - width / 2;
     });
   }
 

--- a/lib/src/widget_stage.dart
+++ b/lib/src/widget_stage.dart
@@ -37,6 +37,7 @@ class _WidgetStageState extends State<WidgetStage> {
               children: [
                 Expanded(
                   child: Stage(
+                    stageController: _stageController,
                     child: _stageController.selectedWidget?.widgetBuilder(context) ?? const SizedBox(),
                   ),
                 ),
@@ -70,14 +71,17 @@ class Stage extends StatelessWidget {
   const Stage({
     super.key,
     required this.child,
+    required this.stageController,
   });
 
   final Widget child;
+  final StageController stageController;
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: FlexibleStage(
+        stageController: stageController,
         child: Center(
           child: child,
         ),

--- a/lib/src/widget_stage_data.dart
+++ b/lib/src/widget_stage_data.dart
@@ -72,4 +72,6 @@ abstract class WidgetStageData {
   Widget widgetBuilder(BuildContext context);
 
   List<FieldConfigurator> get fieldConfigurators;
+
+  Size? get stageSize => const Size(600, 800);
 }


### PR DESCRIPTION
- This adds a nice chessboard pattern to the ColorPickerField when a color with transparency or no color at all is selected. (Credits to @danielmolnar)

- This also adds a stageSize field to the WidgetStageData to set a stage size for the individual widget.

- Last but not least this gets rid of the background color of the stage and adds a small border instead. Room to improve but it looks way nicer with little effort.