### PR TITLE
Adjust appearance

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-
   final ThemeData theme = ThemeData.light();
 
   late final StageController _stageController = StageController(theme: theme);

--- a/example/lib/stage_data/my_list_tile_widget_stage.dart
+++ b/example/lib/stage_data/my_list_tile_widget_stage.dart
@@ -6,7 +6,6 @@ class MyListTileWidgetStage extends WidgetStageData {
       : _tileCount = IntFieldConfigurator(value: 1, name: 'tileCount'),
         _listPadding = PaddingFieldConfigurator(value: EdgeInsets.zero, name: 'listPadding'),
         _title = StringFieldConfigurator(value: 'My List Tile', name: 'title'),
-        _stageColor = ColorFieldConfigurator(value: Colors.transparent, name: 'stageColor'),
         _circleColor = ColorFieldConfigurator(value: Colors.purple, name: 'circleColor'),
         _tileColor = ColorFieldConfiguratorNullable(value: Colors.cyan, name: 'tileColor'),
         _textColor = ColorFieldConfiguratorNullable(value: Colors.white, name: 'textColor'),
@@ -30,7 +29,6 @@ class MyListTileWidgetStage extends WidgetStageData {
       _tileCount,
       _tileGap,
       _listPadding,
-      _stageColor,
       _circleColor,
     ];
   }
@@ -43,30 +41,26 @@ class MyListTileWidgetStage extends WidgetStageData {
   final DoubleFieldConfiguratorNullable _borderRadius;
   final PaddingFieldConfigurator _listPadding;
   final StringFieldConfigurator _title;
-  final ColorFieldConfigurator _stageColor;
   final ColorFieldConfigurator _circleColor;
   final ColorFieldConfiguratorNullable _textColor;
   final ColorFieldConfiguratorNullable _tileColor;
 
   @override
   Widget widgetBuilder(BuildContext context) {
-    return ColoredBox(
-      color: _stageColor.value,
-      child: ListView.separated(
-        padding: _listPadding.value,
-        itemCount: _tileCount.value,
-        separatorBuilder: (_, __) => SizedBox(height: _tileGap.value),
-        itemBuilder: (context, index) {
-          return _MyTitleTileWidget(
-            title: _title.value,
-            index: index,
-            circleColor: _circleColor.value,
-            tileColor: _tileColor.value,
-            borderRadius: _borderRadius.value,
-            textColor: _textColor.value,
-          );
-        },
-      ),
+    return ListView.separated(
+      padding: _listPadding.value,
+      itemCount: _tileCount.value,
+      separatorBuilder: (_, __) => SizedBox(height: _tileGap.value),
+      itemBuilder: (context, index) {
+        return _MyTitleTileWidget(
+          title: _title.value,
+          index: index,
+          circleColor: _circleColor.value,
+          tileColor: _tileColor.value,
+          borderRadius: _borderRadius.value,
+          textColor: _textColor.value,
+        );
+      },
     );
   }
 }

--- a/example/lib/stage_data/my_list_tile_widget_stage.dart
+++ b/example/lib/stage_data/my_list_tile_widget_stage.dart
@@ -29,7 +29,6 @@ class MyListTileWidgetStage extends WidgetStageData {
       _tileCount,
       _tileGap,
       _listPadding,
-      _circleColor,
     ];
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -70,14 +70,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
-  flutter_lints:
-    dependency: "direct dev"
-    description:
-      name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -92,21 +84,13 @@ packages:
     source: hosted
     version: "0.6.7"
   lint:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: lint
-      sha256: "3e9343b1cededcfb1e8b40d0dbd3592b7a1c6c0121545663a991433390c2bc97"
+      sha256: f4bd4dbaa39f4ae8836f2d1275f2f32bc68b3a8cce0a0735dd1f7a601f06682a
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
-  lints:
-    dependency: transitive
-    description:
-      name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
+    version: "2.1.2"
   matcher:
     dependency: transitive
     description:
@@ -208,5 +192,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,15 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  lint: ^2.0.1
 
   stage_craft:
     path: ../
 
 
 dev_dependencies:
-  flutter_lints: ^2.0.0
-
+  lint: ^2.1.2
   flutter_test:
     sdk: flutter
 

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,10 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:example/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -52,59 +52,65 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return AlertDialog(
-              title: const Text('Pick a color!'),
-              content: SingleChildScrollView(
-                child: ColorPicker(
-                  pickerColor: widget.value ?? Colors.white,
-                  onColorChanged: (newColor) {
-                    color = newColor;
-                  },
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () async {
+          showDialog(
+            context: context,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                title: const Text('Pick a color!'),
+                content: SingleChildScrollView(
+                  child: ColorPicker(
+                    pickerColor: widget.value ?? Colors.white,
+                    onColorChanged: (newColor) {
+                      color = newColor;
+                    },
+                  ),
+                ),
+                actions: <Widget>[
+                  ElevatedButton(
+                    child: const Text('Abort'),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                  ElevatedButton(
+                    child: const Text('Accept'),
+                    onPressed: () {
+                      widget.updateValue(color);
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ],
+              );
+            },
+          );
+        },
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Container(
+              height: 38,
+              width: 38,
+              foregroundDecoration: BoxDecoration(
+                // The actual color drawn over the chessboard pattern
+                color: widget.value,
+              ),
+              // The chessboard pattern
+              child: const CustomPaint(
+                foregroundPainter: ChessBoardPainter(
+                  boxSize: 8,
+                  // The color of the chessboard pattern
+                  color: Colors.grey,
+                ),
+                child: ColoredBox(
+                  // Background of the chessboard pattern
+                  color: Colors.white,
                 ),
               ),
-              actions: <Widget>[
-                ElevatedButton(
-                  child: const Text('Abort'),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                ),
-                ElevatedButton(
-                  child: const Text('Accept'),
-                  onPressed: () {
-                    widget.updateValue(color);
-                    Navigator.of(context).pop();
-                  },
-                ),
-              ],
-            );
-          },
-        );
-      },
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(8),
-        child: Container(
-          height: 48,
-          width: 48,
-          foregroundDecoration: BoxDecoration(
-            // The actual color drawn over the chessboard pattern
-            color: widget.value,
-          ),
-          // The chessboard pattern
-          child: const CustomPaint(
-            foregroundPainter: ChessBoardPainter(
-              boxSize: 8,
-              // The color of the chessboard pattern
-              color: Colors.grey,
-            ),
-            child: ColoredBox(
-              // Background of the chessboard pattern
-              color: Colors.white,
             ),
           ),
         ),

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -52,44 +52,44 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        onTap: () async {
-          showDialog(
-            context: context,
-            builder: (BuildContext context) {
-              return AlertDialog(
-                title: const Text('Pick a color!'),
-                content: SingleChildScrollView(
-                  child: ColorPicker(
-                    pickerColor: widget.value ?? Colors.white,
-                    onColorChanged: (newColor) {
-                      color = newColor;
-                    },
-                  ),
+    return GestureDetector(
+      onTap: () async {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text('Pick a color!'),
+              content: SingleChildScrollView(
+                child: ColorPicker(
+                  pickerColor: widget.value ?? Colors.white,
+                  onColorChanged: (newColor) {
+                    color = newColor;
+                  },
                 ),
-                actions: <Widget>[
-                  ElevatedButton(
-                    child: const Text('Abort'),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                  ElevatedButton(
-                    child: const Text('Accept'),
-                    onPressed: () {
-                      widget.updateValue(color);
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ],
-              );
-            },
-          );
-        },
-        child: Align(
-          alignment: Alignment.centerRight,
+              ),
+              actions: <Widget>[
+                ElevatedButton(
+                  child: const Text('Abort'),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                ),
+                ElevatedButton(
+                  child: const Text('Accept'),
+                  onPressed: () {
+                    widget.updateValue(color);
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ],
+            );
+          },
+        );
+      },
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
             child: Container(

--- a/lib/src/field_configurators/color_field_configurator.dart
+++ b/lib/src/field_configurators/color_field_configurator.dart
@@ -12,7 +12,7 @@ class ColorFieldConfigurator extends FieldConfigurator<Color> {
   @override
   Widget build(BuildContext context) {
     return ColorConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: (Color? color) {
         updateValue(color ?? Colors.transparent);
       },
@@ -30,7 +30,7 @@ class ColorFieldConfiguratorNullable extends FieldConfigurator<Color?> {
   @override
   Widget build(BuildContext context) {
     return ColorConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: updateValue,
     );
   }
@@ -39,7 +39,7 @@ class ColorFieldConfiguratorNullable extends FieldConfigurator<Color?> {
 class ColorConfigurationWidget extends StatefulConfigurationWidget<Color?> {
   const ColorConfigurationWidget({
     super.key,
-    required super.value,
+    required super.configurator,
     required super.updateValue,
   });
 
@@ -48,7 +48,7 @@ class ColorConfigurationWidget extends StatefulConfigurationWidget<Color?> {
 }
 
 class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
-  late Color? color = widget.value;
+  late Color? color = widget.configurator.value;
 
   @override
   Widget build(BuildContext context) {
@@ -61,7 +61,7 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
               title: const Text('Pick a color!'),
               content: SingleChildScrollView(
                 child: ColorPicker(
-                  pickerColor: widget.value ?? Colors.white,
+                  pickerColor: color ?? Colors.white,
                   onColorChanged: (newColor) {
                     color = newColor;
                   },
@@ -97,7 +97,7 @@ class _ColorConfigurationFieldState extends State<ColorConfigurationWidget> {
               width: 38,
               foregroundDecoration: BoxDecoration(
                 // The actual color drawn over the chessboard pattern
-                color: widget.value,
+                color: widget.configurator.value,
               ),
               // The chessboard pattern
               child: const CustomPaint(

--- a/lib/src/field_configurators/double_field_configurator.dart
+++ b/lib/src/field_configurators/double_field_configurator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:stage_craft/src/field_configurators/field_configurator_widget.dart';
 import 'package:stage_craft/stage_craft.dart';
 
@@ -53,19 +54,14 @@ class _DoubleFieldConfigurationWidgetState extends State<DoubleFieldConfiguratio
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      decoration: const InputDecoration(
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.all(
-            Radius.circular(8),
-          ),
-        ),
-      ),
+    return FieldConfiguratorInputField(
       controller: _controller,
-      onChanged: (newValue) {
-        widget.updateValue(
-          double.tryParse(newValue),
-        );
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(RegExp('[0-9,.]')),
+      ],
+      onChanged: (value) {
+        final replacedComma = value.replaceAll(',', '.');
+        widget.updateValue(double.tryParse(replacedComma));
       },
     );
   }

--- a/lib/src/field_configurators/double_field_configurator.dart
+++ b/lib/src/field_configurators/double_field_configurator.dart
@@ -13,7 +13,7 @@ class DoubleFieldConfiguratorNullable extends FieldConfigurator<double?> {
   @override
   Widget build(BuildContext context) {
     return DoubleFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: updateValue,
     );
   }
@@ -29,7 +29,7 @@ class DoubleFieldConfigurator extends FieldConfigurator<double> {
   @override
   Widget build(BuildContext context) {
     return DoubleFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: (value) {
         updateValue(value ?? 0.0);
       },
@@ -40,7 +40,7 @@ class DoubleFieldConfigurator extends FieldConfigurator<double> {
 class DoubleFieldConfigurationWidget extends StatefulConfigurationWidget<double?> {
   const DoubleFieldConfigurationWidget({
     super.key,
-    required super.value,
+    required super.configurator,
     required super.updateValue,
   });
 
@@ -49,8 +49,21 @@ class DoubleFieldConfigurationWidget extends StatefulConfigurationWidget<double?
 }
 
 class _DoubleFieldConfigurationWidgetState extends State<DoubleFieldConfigurationWidget> {
-  // for example
-  late final TextEditingController _controller = TextEditingController(text: widget.value.toString());
+
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    _controller = TextEditingController(
+      text: widget.configurator.value.toString(),
+    );
+    widget.configurator.addListener(() {
+      if(widget.configurator.value == null) {
+        _controller.text = '';
+      }
+    });
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/field_configurators/field_configurator_widget.dart
+++ b/lib/src/field_configurators/field_configurator_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:stage_craft/src/widget_stage.dart';
 
 class FieldConfiguratorWidget<T> extends StatelessWidget {
@@ -13,28 +14,79 @@ class FieldConfiguratorWidget<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Expanded(
-          child: Text('${fieldConfigurator.name}:'),
-        ),
-        Expanded(
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (fieldConfigurator.isNullable) ...[
-                const SizedBox(width: 4.0),
-                TextButton(
-                  onPressed: () => fieldConfigurator.updateValue(null),
-                  child: const Text('null'),
-                ),
+    return Padding(
+      padding: const EdgeInsets.only(left: 12.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(
+              '${fieldConfigurator.name}:',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Expanded(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (fieldConfigurator.isNullable) ...[
+                  NullableButton(
+                    fieldConfigurator: fieldConfigurator,
+                  ),
+                  const SizedBox(width: 4.0),
+                ],
+                Expanded(child: child),
               ],
-              Expanded(child: child),
-            ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class NullableButton extends StatefulWidget {
+  const NullableButton({
+    super.key,
+    required this.fieldConfigurator,
+  });
+
+  final FieldConfigurator fieldConfigurator;
+
+  @override
+  State<NullableButton> createState() => _NullableButtonState();
+}
+
+class _NullableButtonState extends State<NullableButton> {
+  bool _isHovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final isNull = widget.fieldConfigurator.value == null;
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovering = true),
+      onExit: (_) => setState(() => _isHovering = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => widget.fieldConfigurator.updateValue(null),
+        child: Container(
+          decoration: BoxDecoration(
+            color: isNull || _isHovering ? Colors.blue.withOpacity(0.2) : Colors.transparent,
+            shape: BoxShape.circle,
+            border: Border.all(color: isNull ? Colors.blue : Colors.grey),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(6.0),
+            child: Center(
+              child: Text(
+                'null',
+                textScaleFactor: 0.6,
+                style: TextStyle(color: isNull ? Colors.blue : Colors.grey),
+              ),
+            ),
           ),
         ),
-      ],
+      ),
     );
   }
 }
@@ -59,4 +111,57 @@ abstract class StatefulConfigurationWidget<T> extends StatefulWidget {
 
   final T value;
   final void Function(T newValue) updateValue;
+}
+
+class FieldConfiguratorInputField extends StatefulWidget {
+  const FieldConfiguratorInputField({
+    super.key,
+    required this.controller,
+    this.inputFormatters,
+    this.onChanged,
+  });
+
+  final List<TextInputFormatter>? inputFormatters;
+  final TextEditingController controller;
+  final void Function(String value)? onChanged;
+
+  @override
+  State<FieldConfiguratorInputField> createState() => _FieldConfiguratorInputFieldState();
+}
+
+class _FieldConfiguratorInputFieldState extends State<FieldConfiguratorInputField> {
+  bool _isHovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovering = true),
+      onExit: (_) => setState(() => _isHovering = false),
+      child: SizedBox(
+        height: 30,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.blue.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(2),
+            border: Border.all(
+              color: _isHovering ? Colors.blue.withOpacity(0.5) : Colors.transparent,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            child: TextField(
+              decoration: const InputDecoration(
+                isDense: true,
+                border: InputBorder.none,
+              ),
+              inputFormatters: widget.inputFormatters,
+              keyboardType: TextInputType.number,
+              controller: widget.controller,
+              onChanged: widget.onChanged,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/field_configurators/field_configurator_widget.dart
+++ b/lib/src/field_configurators/field_configurator_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:stage_craft/src/widget_stage.dart';
 
-class FieldConfiguratorWidget<T> extends StatelessWidget {
+class FieldConfiguratorWidget<T> extends StatefulWidget {
   const FieldConfiguratorWidget({
     super.key,
     required this.fieldConfigurator,
@@ -13,6 +13,11 @@ class FieldConfiguratorWidget<T> extends StatelessWidget {
   final FieldConfigurator fieldConfigurator;
 
   @override
+  State<FieldConfiguratorWidget<T>> createState() => _FieldConfiguratorWidgetState<T>();
+}
+
+class _FieldConfiguratorWidgetState<T> extends State<FieldConfiguratorWidget<T>> {
+  @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(left: 12.0),
@@ -21,7 +26,7 @@ class FieldConfiguratorWidget<T> extends StatelessWidget {
         children: [
           Expanded(
             child: Text(
-              '${fieldConfigurator.name}:',
+              '${widget.fieldConfigurator.name}:',
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
           ),
@@ -29,13 +34,13 @@ class FieldConfiguratorWidget<T> extends StatelessWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                if (fieldConfigurator.isNullable) ...[
+                if (widget.fieldConfigurator.isNullable) ...[
                   NullableButton(
-                    fieldConfigurator: fieldConfigurator,
+                    fieldConfigurator: widget.fieldConfigurator,
                   ),
                   const SizedBox(width: 4.0),
                 ],
-                Expanded(child: child),
+                Expanded(child: widget.child),
               ],
             ),
           ),
@@ -105,11 +110,11 @@ abstract class ConfigurationWidget<T> extends StatelessWidget {
 abstract class StatefulConfigurationWidget<T> extends StatefulWidget {
   const StatefulConfigurationWidget({
     super.key,
-    required this.value,
+    required this.configurator,
     required this.updateValue,
   });
 
-  final T value;
+  final FieldConfigurator<T> configurator;
   final void Function(T newValue) updateValue;
 }
 

--- a/lib/src/field_configurators/field_configurator_widget.dart
+++ b/lib/src/field_configurators/field_configurator_widget.dart
@@ -66,7 +66,7 @@ class _NullableButtonState extends State<NullableButton> {
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovering = true),
       onExit: (_) => setState(() => _isHovering = false),
-      cursor: SystemMouseCursors.click,
+      cursor: isNull ? SystemMouseCursors.basic : SystemMouseCursors.click,
       child: GestureDetector(
         onTap: () => widget.fieldConfigurator.updateValue(null),
         child: Container(

--- a/lib/src/field_configurators/int_field_configurator.dart
+++ b/lib/src/field_configurators/int_field_configurator.dart
@@ -13,7 +13,7 @@ class IntFieldConfiguratorNullable extends FieldConfigurator<int?> {
   @override
   Widget build(BuildContext context) {
     return IntFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: updateValue,
     );
   }
@@ -29,7 +29,7 @@ class IntFieldConfigurator extends FieldConfigurator<int> {
   @override
   Widget build(BuildContext context) {
     return IntFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: (value) {
         updateValue(value ?? 0);
       },
@@ -40,7 +40,7 @@ class IntFieldConfigurator extends FieldConfigurator<int> {
 class IntFieldConfigurationWidget extends StatefulConfigurationWidget<int?> {
   const IntFieldConfigurationWidget({
     super.key,
-    required super.value,
+    required super.configurator,
     required super.updateValue,
   });
 
@@ -49,8 +49,20 @@ class IntFieldConfigurationWidget extends StatefulConfigurationWidget<int?> {
 }
 
 class _IntFieldConfigurationWidgetState extends State<IntFieldConfigurationWidget> {
-  // for example
-  late final TextEditingController _controller = TextEditingController(text: widget.value.toString());
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    _controller = TextEditingController(
+      text: widget.configurator.value.toString(),
+    );
+    widget.configurator.addListener(() {
+      if(widget.configurator.value == null) {
+        _controller.text = '';
+      }
+    });
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/field_configurators/int_field_configurator.dart
+++ b/lib/src/field_configurators/int_field_configurator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:stage_craft/src/field_configurators/field_configurator_widget.dart';
 import 'package:stage_craft/stage_craft.dart';
 
@@ -53,19 +54,13 @@ class _IntFieldConfigurationWidgetState extends State<IntFieldConfigurationWidge
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      decoration: const InputDecoration(
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.all(
-            Radius.circular(8),
-          ),
-        ),
-      ),
+    return FieldConfiguratorInputField(
       controller: _controller,
-      onChanged: (newValue) {
-        widget.updateValue(
-          int.tryParse(newValue),
-        );
+      inputFormatters: [
+        FilteringTextInputFormatter.digitsOnly,
+      ],
+      onChanged: (value) {
+        widget.updateValue(int.tryParse(value));
       },
     );
   }

--- a/lib/src/field_configurators/padding_field_configurator.dart
+++ b/lib/src/field_configurators/padding_field_configurator.dart
@@ -13,7 +13,7 @@ class PaddingFieldConfiguratorNullable extends FieldConfigurator<EdgeInsets?> {
   @override
   Widget build(BuildContext context) {
     return PaddingFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: updateValue,
     );
   }
@@ -29,7 +29,7 @@ class PaddingFieldConfigurator extends FieldConfigurator<EdgeInsets> {
   @override
   Widget build(BuildContext context) {
     return PaddingFieldConfigurationWidget(
-      value: value,
+        configurator: this,
       updateValue: (value) => updateValue(value ?? EdgeInsets.zero),
     );
   }
@@ -38,7 +38,7 @@ class PaddingFieldConfigurator extends FieldConfigurator<EdgeInsets> {
 class PaddingFieldConfigurationWidget extends StatefulConfigurationWidget<EdgeInsets?> {
   const PaddingFieldConfigurationWidget({
     super.key,
-    required super.value,
+    required super.configurator,
     required super.updateValue,
   });
 
@@ -49,11 +49,11 @@ class PaddingFieldConfigurationWidget extends StatefulConfigurationWidget<EdgeIn
 class _PaddingFieldConfigurationWidgetState extends State<PaddingFieldConfigurationWidget> {
   @override
   Widget build(BuildContext context) {
-    final padding = widget.value ?? EdgeInsets.zero;
+    final padding = widget.configurator.value ?? EdgeInsets.zero;
     return Column(
       children: [
         _PaddingField(
-          value: widget.value?.top,
+          value: padding.top,
           onChanged: (value) {
             setState(() {
               final newValue = padding.copyWith(top: value);
@@ -67,7 +67,7 @@ class _PaddingFieldConfigurationWidgetState extends State<PaddingFieldConfigurat
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             _PaddingField(
-              value: widget.value?.left,
+              value: padding.left,
               onChanged: (value) {
                 setState(() {
                   final newValue = padding.copyWith(left: value);
@@ -78,7 +78,7 @@ class _PaddingFieldConfigurationWidgetState extends State<PaddingFieldConfigurat
             ),
             const SizedBox(width: 8.0),
             _PaddingField(
-              value: widget.value?.right,
+              value: padding.right,
               onChanged: (value) {
                 setState(() {
                   final newValue = padding.copyWith(right: value);
@@ -91,7 +91,7 @@ class _PaddingFieldConfigurationWidgetState extends State<PaddingFieldConfigurat
         ),
         const SizedBox(height: 8.0),
         _PaddingField(
-          value: widget.value?.bottom,
+          value: padding.bottom,
           onChanged: (value) {
             setState(() {
               final newValue = padding.copyWith(bottom: value);

--- a/lib/src/field_configurators/padding_field_configurator.dart
+++ b/lib/src/field_configurators/padding_field_configurator.dart
@@ -52,65 +52,53 @@ class _PaddingFieldConfigurationWidgetState extends State<PaddingFieldConfigurat
     final padding = widget.value ?? EdgeInsets.zero;
     return Column(
       children: [
-        SizedBox(
-          width: 80,
-          child: _PaddingField(
-            value: widget.value?.top,
-            onChanged: (value) {
-              setState(() {
-                final newValue = padding.copyWith(top: value);
-                widget.updateValue(newValue);
-              });
-            },
-            label: 'top',
-          ),
+        _PaddingField(
+          value: widget.value?.top,
+          onChanged: (value) {
+            setState(() {
+              final newValue = padding.copyWith(top: value);
+              widget.updateValue(newValue);
+            });
+          },
+          label: 'top',
         ),
         const SizedBox(height: 8.0),
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            SizedBox(
-              width: 60,
-              child: _PaddingField(
-                value: widget.value?.left,
-                onChanged: (value) {
-                  setState(() {
-                    final newValue = padding.copyWith(left: value);
-                    widget.updateValue(newValue);
-                  });
-                },
-                label: 'left',
-              ),
+            _PaddingField(
+              value: widget.value?.left,
+              onChanged: (value) {
+                setState(() {
+                  final newValue = padding.copyWith(left: value);
+                  widget.updateValue(newValue);
+                });
+              },
+              label: 'left',
             ),
             const SizedBox(width: 8.0),
-            SizedBox(
-              width: 60,
-              child: _PaddingField(
-                value: widget.value?.right,
-                onChanged: (value) {
-                  setState(() {
-                    final newValue = padding.copyWith(right: value);
-                    widget.updateValue(newValue);
-                  });
-                },
-                label: 'right',
-              ),
+            _PaddingField(
+              value: widget.value?.right,
+              onChanged: (value) {
+                setState(() {
+                  final newValue = padding.copyWith(right: value);
+                  widget.updateValue(newValue);
+                });
+              },
+              label: 'right',
             ),
           ],
         ),
         const SizedBox(height: 8.0),
-        SizedBox(
-          width: 80,
-          child: _PaddingField(
-            value: widget.value?.bottom,
-            onChanged: (value) {
-              setState(() {
-                final newValue = padding.copyWith(bottom: value);
-                widget.updateValue(newValue);
-              });
-            },
-            label: 'bottom',
-          ),
+        _PaddingField(
+          value: widget.value?.bottom,
+          onChanged: (value) {
+            setState(() {
+              final newValue = padding.copyWith(bottom: value);
+              widget.updateValue(newValue);
+            });
+          },
+          label: 'bottom',
         ),
       ],
     );
@@ -154,24 +142,19 @@ class _PaddingFieldState extends State<_PaddingField> {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      inputFormatters: <TextInputFormatter>[
-        // Allow only digits, dot and 1 decimal
-        FilteringTextInputFormatter.allow(RegExp(r'^\d+\.?\d?')),
-      ],
-      decoration: InputDecoration(
-        labelText: widget.label,
-        isDense: true,
-        border: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(
-            Radius.circular(8),
-          ),
-        ),
+    return SizedBox(
+      height: 30,
+      width: 60,
+      child: FieldConfiguratorInputField(
+        controller: _controller,
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(RegExp('[0-9,.]')),
+        ],
+        onChanged: (value) {
+          final replacedComma = value.replaceAll(',', '.');
+          widget.onChanged(double.tryParse(replacedComma) ?? 0);
+        },
       ),
-      controller: _controller,
-      onChanged: (value) {
-        widget.onChanged.call(double.tryParse(value) ?? 0);
-      },
     );
   }
 }

--- a/lib/src/field_configurators/string_field_configurator.dart
+++ b/lib/src/field_configurators/string_field_configurator.dart
@@ -12,7 +12,7 @@ class StringFieldConfiguratorNullable extends FieldConfigurator<String?> {
   @override
   Widget build(BuildContext context) {
     return StringFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: updateValue,
     );
   }
@@ -28,7 +28,7 @@ class StringFieldConfigurator extends FieldConfigurator<String> {
   @override
   Widget build(BuildContext context) {
     return StringFieldConfigurationWidget(
-      value: value,
+      configurator: this,
       updateValue: (value) {
         updateValue(value ?? '');
       },
@@ -39,7 +39,7 @@ class StringFieldConfigurator extends FieldConfigurator<String> {
 class StringFieldConfigurationWidget extends StatefulConfigurationWidget<String?> {
   const StringFieldConfigurationWidget({
     super.key,
-    required super.value,
+    required super.configurator,
     required super.updateValue,
   });
 
@@ -48,7 +48,20 @@ class StringFieldConfigurationWidget extends StatefulConfigurationWidget<String?
 }
 
 class _StringFieldConfigurationWidgetState extends State<StringFieldConfigurationWidget> {
-  late final TextEditingController _controller = TextEditingController(text: widget.value);
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    _controller = TextEditingController(
+      text: widget.configurator.value.toString(),
+    );
+    widget.configurator.addListener(() {
+      if(widget.configurator.value == null) {
+        _controller.text = '';
+      }
+    });
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/field_configurators/string_field_configurator.dart
+++ b/lib/src/field_configurators/string_field_configurator.dart
@@ -52,14 +52,7 @@ class _StringFieldConfigurationWidgetState extends State<StringFieldConfiguratio
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      decoration: const InputDecoration(
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.all(
-            Radius.circular(8),
-          ),
-        ),
-      ),
+    return FieldConfiguratorInputField(
       controller: _controller,
       onChanged: widget.updateValue,
     );

--- a/lib/src/stage_settings.dart
+++ b/lib/src/stage_settings.dart
@@ -17,6 +17,13 @@ class StageSettingsWidget extends StatelessWidget {
       decoration: BoxDecoration(
         color: const Color(0xFFE0E0E0),
         borderRadius: BorderRadius.circular(8),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x33000000),
+            blurRadius: 4,
+            offset: Offset(2, 2),
+          ),
+        ],
       ),
       child: Row(
         children: [
@@ -60,6 +67,13 @@ class StageSettingsWidget extends StatelessWidget {
                   decoration: BoxDecoration(
                     color: stageController.backgroundColor,
                     shape: BoxShape.circle,
+                    boxShadow:  const [
+                      BoxShadow(
+                        color: Color(0x33000000),
+                        blurRadius: 1,
+                        offset: Offset(-0.5, -0.5),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/src/widget_stage.dart
+++ b/lib/src/widget_stage.dart
@@ -56,14 +56,16 @@ class _WidgetStageState extends State<WidgetStage> {
           width: 400,
           child: ConfigurationBar(
             fields: [
-              _ConfiguratorGroup(
-                title: 'Widget Arguments',
-                configurators: widgetConfigurators,
-              ),
-              _ConfiguratorGroup(
-                title: 'Stage Arguments',
-                configurators: stageConfigurators,
-              ),
+              if (widgetConfigurators?.isNotEmpty == true)
+                _ConfiguratorGroup(
+                  title: 'Widget',
+                  configurators: widgetConfigurators,
+                ),
+              if (stageConfigurators?.isNotEmpty == true)
+                _ConfiguratorGroup(
+                  title: 'Stage',
+                  configurators: stageConfigurators,
+                ),
             ],
           ),
         ),
@@ -83,38 +85,49 @@ class _ConfiguratorGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          padding: const EdgeInsets.only(bottom: 4.0),
-          decoration: BoxDecoration(
-            border: Border(
-              bottom: BorderSide(color: Colors.grey.shade400),
-            ),
-          ),
-          width: double.infinity,
-          child: Text(
-            textAlign: TextAlign.center,
-            title,
-            style: TextStyle(
-              color: Colors.grey.shade400,
-            ),
-          ),
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        color: Colors.blue.withOpacity(0.1),
+        border: Border.all(
+          color: Colors.blue.withOpacity(0.2),
         ),
-        const SizedBox(
-          height: 8,
-        ),
-        ...?configurators?.map((configurator) {
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: FieldConfiguratorWidget(
-              fieldConfigurator: configurator,
-              child: configurator.build(context),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 16),
+              child: Center(
+                child: Text(
+                  textAlign: TextAlign.center,
+                  title,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    color: Colors.black,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
             ),
-          );
-        }),
-      ],
+            Divider(
+              color: Colors.blue.withOpacity(0.2),
+              thickness: 1,
+            ),
+            ...?configurators?.map((configurator) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: FieldConfiguratorWidget(
+                  fieldConfigurator: configurator,
+                  child: configurator.build(context),
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -242,7 +255,7 @@ class StageController extends ChangeNotifier {
     notifyListeners();
   }
 
-  late Color _backgroundColor = theme.colorScheme.background;
+  late Color _backgroundColor = theme.canvasColor;
 
   Color get backgroundColor => _backgroundColor;
 
@@ -252,7 +265,7 @@ class StageController extends ChangeNotifier {
   }
 
   void resetBackgroundColor() {
-    _backgroundColor = theme.colorScheme.background;
+    _backgroundColor = theme.canvasColor;
     notifyListeners();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -87,10 +87,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lint:
     dependency: "direct main"
     description:
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -127,18 +127,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -201,5 +201,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,14 +70,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
-  flutter_lints:
-    dependency: "direct dev"
-    description:
-      name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -92,21 +84,13 @@ packages:
     source: hosted
     version: "0.6.7"
   lint:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: lint
-      sha256: "3e9343b1cededcfb1e8b40d0dbd3592b7a1c6c0121545663a991433390c2bc97"
+      sha256: f4bd4dbaa39f4ae8836f2d1275f2f32bc68b3a8cce0a0735dd1f7a601f06682a
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
-  lints:
-    dependency: transitive
-    description:
-      name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
+    version: "2.1.2"
   matcher:
     dependency: transitive
     description:
@@ -201,5 +185,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,4 +24,7 @@ dev_dependencies:
 
 flutter:
 
+  assets:
+    - assets/
+
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,17 +14,13 @@ dependencies:
     sdk: flutter
 
   flutter_colorpicker: ^1.0.3
-  lint: ^2.0.1
 
 dev_dependencies:
-  flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
+  lint: ^2.1.2
 
 
 flutter:
-
-  assets:
-    - assets/
 
   uses-material-design: true


### PR DESCRIPTION
This tries to achieve a bit more coherent UI for the configurators. The main purpose was to make the input fields a bit thinner so they don't take to much space. Previously the default material height for mobile was used.

Every input field like for string, double, int etc. use the `FieldConfiguratorWidget` now so we only have one point to improve this further or change it completely if we want to.


As a bonus this also fixes a bug on `double` and `int` configurators not being updated when `null` was pressed.

| Before | After |
|--------|---------|
|     <img width="1274" alt="image" src="https://github.com/robiness/stage_craft/assets/34774539/0b448b93-2b0b-49f4-9145-37a8541ae6dd"> |   <img width="1297" alt="image" src="https://github.com/robiness/stage_craft/assets/34774539/af6c0193-3326-4107-b626-3af19b784c85">     |