### PR TITLE
Add optional footer to configuration bar

### DIFF
--- a/lib/src/widgets/configuration_bar.dart
+++ b/lib/src/widgets/configuration_bar.dart
@@ -5,10 +5,15 @@ import 'package:stage_craft/src/stage_controller.dart';
 class ConfigurationBar extends StatefulWidget {
   const ConfigurationBar({
     super.key,
+    this.configurationBarFooter,
     required this.controller,
   });
 
+  /// The controller of the stage.
   final StageController controller;
+
+  /// An optional footer of the configuration bar.
+  final Widget? configurationBarFooter;
 
   @override
   State<ConfigurationBar> createState() => _ConfigurationBarState();
@@ -51,6 +56,7 @@ class _ConfigurationBarState extends State<ConfigurationBar> {
                   title: 'Stage',
                   configurators: stageConfigurators,
                 ),
+              if (widget.configurationBarFooter != null) widget.configurationBarFooter!
             ],
           ),
         ),

--- a/lib/src/widgets/stage_craft.dart
+++ b/lib/src/widgets/stage_craft.dart
@@ -12,6 +12,7 @@ class StageCraft extends StatelessWidget {
   StageCraft({
     super.key,
     required this.stageController,
+    this.widgets = const [],
     this.configurationBarFooter,
     Size? stageSize,
     StageCraftSettings? settings,
@@ -32,6 +33,8 @@ class StageCraft extends StatelessWidget {
 
   /// The size of the handle balls.
   final StageCraftSettings settings;
+
+  final List<WidgetStageData> widgets;
 
   /// An optional footer of the configuration bar.
   final Widget? configurationBarFooter;

--- a/lib/src/widgets/stage_craft.dart
+++ b/lib/src/widgets/stage_craft.dart
@@ -12,7 +12,6 @@ class StageCraft extends StatelessWidget {
   StageCraft({
     super.key,
     required this.stageController,
-    this.widgets = const [],
     this.configurationBarFooter,
     Size? stageSize,
     StageCraftSettings? settings,
@@ -33,8 +32,6 @@ class StageCraft extends StatelessWidget {
 
   /// The size of the handle balls.
   final StageCraftSettings settings;
-
-  final List<WidgetStageData> widgets;
 
   /// An optional footer of the configuration bar.
   final Widget? configurationBarFooter;

--- a/lib/src/widgets/stage_craft.dart
+++ b/lib/src/widgets/stage_craft.dart
@@ -13,6 +13,7 @@ class StageCraft extends StatelessWidget {
     super.key,
     required this.stageController,
     this.widgets = const [],
+    this.configurationBarFooter,
     Size? stageSize,
     StageCraftSettings? settings,
   })  : stageSize = stageSize ?? const Size(600, 800),
@@ -35,6 +36,9 @@ class StageCraft extends StatelessWidget {
 
   final List<WidgetStageData> widgets;
 
+  /// An optional footer of the configuration bar.
+  final Widget? configurationBarFooter;
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -47,6 +51,7 @@ class StageCraft extends StatelessWidget {
           alignment: Alignment.topCenter,
           child: ConfigurationBar(
             controller: stageController,
+            configurationBarFooter: configurationBarFooter,
           ),
         ),
       ],


### PR DESCRIPTION
This PR aims to address issue #16 by adding an optional `configurationBarFooter` parameter to the `configurationBar` .

