### PR TITLE
Fix platform environment error on web

### DIFF
--- a/lib/src/widgets/stage_craft.dart
+++ b/lib/src/widgets/stage_craft.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:stage_craft/src/stage_controller.dart';
 import 'package:stage_craft/src/widget_stage_data.dart';
@@ -68,7 +69,7 @@ class _StageCraftState extends State<StageCraft> {
           settings: widget.settings,
         ),
         // In tests we don't want to show the configuration bar because find() would find widgets in it.
-        if (!Platform.environment.containsKey('FLUTTER_TEST'))
+        if (!kIsWeb && !Platform.environment.containsKey('FLUTTER_TEST'))
           Align(
             alignment: Alignment.topCenter,
             child: ConfigurationBar(


### PR DESCRIPTION
This PR fixes an error that occurred because the `Platform.environment` property is not supported by the web platform.

```
Unsupported operation: Platform._environment
```