### PR TITLE
Add universal_io dependency and show configuration bar on web

### DIFF
--- a/lib/src/widgets/stage_craft.dart
+++ b/lib/src/widgets/stage_craft.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:stage_craft/src/stage_controller.dart';
 import 'package:stage_craft/src/widget_stage_data.dart';
 import 'package:stage_craft/src/widgets/configuration_bar.dart';
 import 'package:stage_craft/src/widgets/stage_area.dart';
+import 'package:universal_io/io.dart';
 
 /// The [StageCraft] widget is the main widget of the StageCraft package.
 ///
@@ -69,7 +67,7 @@ class _StageCraftState extends State<StageCraft> {
           settings: widget.settings,
         ),
         // In tests we don't want to show the configuration bar because find() would find widgets in it.
-        if (!kIsWeb && !Platform.environment.containsKey('FLUTTER_TEST'))
+        if (!Platform.environment.containsKey('FLUTTER_TEST'))
           Align(
             alignment: Alignment.topCenter,
             child: ConfigurationBar(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -176,6 +176,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
+  universal_io:
+    dependency: "direct main"
+    description:
+      name: universal_io
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
 
   flutter_colorpicker: ^1.0.3
+  universal_io: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- [x] Use universal_io dependency that works on all platforms, including browsers.
- [x] Show configuration bar on web again