### PR TITLE
Allow text field values for DoubleFieldConfigurator to be negativ

### DIFF
--- a/lib/src/field_configurators/double_field_configurator.dart
+++ b/lib/src/field_configurators/double_field_configurator.dart
@@ -48,7 +48,6 @@ class DoubleFieldConfigurationWidget extends StatefulConfigurationWidget<double?
 }
 
 class _DoubleFieldConfigurationWidgetState extends State<DoubleFieldConfigurationWidget> {
-
   late final TextEditingController _controller;
 
   @override
@@ -57,7 +56,7 @@ class _DoubleFieldConfigurationWidgetState extends State<DoubleFieldConfiguratio
       text: widget.configurator.value.toString(),
     );
     widget.configurator.addListener(() {
-      if(widget.configurator.value == null) {
+      if (widget.configurator.value == null) {
         _controller.text = '';
       }
     });
@@ -69,7 +68,7 @@ class _DoubleFieldConfigurationWidgetState extends State<DoubleFieldConfiguratio
     return FieldConfiguratorInputField(
       controller: _controller,
       inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp('[0-9,.]')),
+        FilteringTextInputFormatter.allow(RegExp('-?[0-9.,]')),
       ],
       onChanged: (value) {
         final replacedComma = value.replaceAll(',', '.');


### PR DESCRIPTION
This PR allows text field values for `DoubleFieldConfigurator` to be negative.
Before, it was only possible to insert positive values.

<img width="237" alt="image" src="https://github.com/robiness/stage_craft/assets/78251680/5fa0a364-ec77-423b-97ca-228557aeab5c">
