### PR TITLE
Add missing export for offset field configurator

### DIFF
--- a/lib/src/field_configurators/field_configurator.dart
+++ b/lib/src/field_configurators/field_configurator.dart
@@ -7,6 +7,7 @@ export 'color_field_configurator.dart';
 export 'double_field_configurator.dart';
 export 'enum_field_configurator.dart';
 export 'int_field_configurator.dart';
+export 'offset_field_configurator.dart';
 export 'padding_field_configurator.dart';
 export 'string_field_configurator.dart';
 


### PR DESCRIPTION
This PR adds a missing export for the `OffsetFieldConfigurator` widget.