### PR TITLE
Allow changing the textScaleFactor

### DIFF
--- a/lib/src/stage/control_bar.dart
+++ b/lib/src/stage/control_bar.dart
@@ -17,8 +17,6 @@ class ControlBar extends StatefulWidget {
 }
 
 class _ControlBarState extends State<ControlBar> {
-  bool _expanded = true;
-
   @override
   void initState() {
     super.initState();
@@ -41,59 +39,25 @@ class _ControlBarState extends State<ControlBar> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        AnimatedContainer(
-          duration: const Duration(milliseconds: 350),
-          curve: Curves.easeInOut,
-          alignment: Alignment.centerLeft,
-          width: _expanded ? context.stageStyle.controlPanelWidth + 44 : 48,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Align(
-                alignment: Alignment.topLeft,
-                child: IconButton(
-                  icon: Icon(
-                    _expanded ? Icons.arrow_forward_ios : Icons.arrow_back_ios,
-                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
-                  ),
-                  onPressed: () {
-                    setState(() {
-                      _expanded = !_expanded;
-                    });
-                  },
-                ),
-              ),
-              Container(
-                width: _expanded ? 4 : 8,
-                height: double.infinity,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.15),
-              ),
-            ],
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 4,
+            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.15),
           ),
-        ),
-        AnimatedPositioned(
-          duration: const Duration(milliseconds: 350),
-          curve: Curves.easeInOut,
-          right: _expanded ? 0 : -context.stageStyle.controlPanelWidth,
-          child: SizedBox(
-            width: context.stageStyle.controlPanelWidth,
-            height: MediaQuery.of(context).size.height,
-            child: ColoredBox(
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-              child: Padding(
-                padding: const EdgeInsets.only(left: 2, top: 4, right: 2),
-                child: ListView(
-                  children: widget.controls.map((control) {
-                    return control.builder(context);
-                  }).toList(),
-                ),
-              ),
+          Flexible(
+            child: ListView(
+              padding: const EdgeInsets.only(left: 4, top: 4, right: 4),
+              children: widget.controls.map((control) {
+                return control.builder(context);
+              }).toList(),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/src/stage/settings_bar.dart
+++ b/lib/src/stage/settings_bar.dart
@@ -3,21 +3,17 @@ import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:stage_craft/src/stage/stage.dart';
 
 /// A settings bar that allows the user to toggle and adjust various stage settings.
-class SettingsBar extends StatelessWidget {
+class SettingsBarCenter extends StatelessWidget {
   /// Creates a new settings bar.
-  const SettingsBar({
+  const SettingsBarCenter({
     super.key,
-    required this.settings,
-    required this.onSettingsChanged,
+    required this.canvasController,
     required this.onStyleToggled,
     required this.onSurfaceColorChanged,
   });
 
-  /// The current settings.
-  final StageSettings settings;
-
-  /// Called when the settings are changed.
-  final void Function(StageSettings settings) onSettingsChanged;
+  /// The canvas controller to manipulate the stage.
+  final StageCanvasController canvasController;
 
   /// Called when the style is toggled.
   final VoidCallback onStyleToggled;
@@ -27,94 +23,278 @@ class SettingsBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: Colors.grey.withOpacity(0.3),
-          width: 2,
-        ),
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(64),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: Icon(
-              Icons.space_bar_sharp,
-              color: settings.showRuler ? Colors.blue : Colors.grey,
+    return ListenableBuilder(
+      listenable: canvasController,
+      builder: (BuildContext context, Widget? child) {
+        return Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.grey.withOpacity(0.3),
+              width: 2,
             ),
-            onPressed: () {
-              onSettingsChanged(
-                settings.copyWith(
-                  showRuler: !settings.showRuler,
-                ),
-              );
-            },
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(64),
           ),
-          IconButton(
-            icon: Container(
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                color: context.stageStyle.canvasColor,
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: Colors.grey,
-                  width: 2,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(
+                  Icons.space_bar_sharp,
+                  color: canvasController.showRuler ? Colors.blue : Colors.grey,
                 ),
+                onPressed: () {
+                  canvasController.showRuler = !canvasController.showRuler;
+                },
               ),
-            ),
-            onPressed: () {
-              showDialog(
-                builder: (_) {
-                  return AlertDialog(
-                    title: const Text('Pick a color!'),
-                    content: SingleChildScrollView(
-                      child: MaterialPicker(
-                        pickerColor: context.stageStyle.canvasColor,
-                        onColorChanged: onSurfaceColorChanged,
-                      ),
+              IconButton(
+                icon: Container(
+                  width: 24,
+                  height: 24,
+                  decoration: BoxDecoration(
+                    color: context.stageStyle.canvasColor,
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: Colors.grey,
+                      width: 2,
                     ),
+                  ),
+                ),
+                onPressed: () {
+                  showDialog(
+                    useRootNavigator: false,
+                    context: context,
+                    builder: (_) {
+                      return AlertDialog(
+                        title: const Text('Pick a color!'),
+                        content: SingleChildScrollView(
+                          child: MaterialPicker(
+                            pickerColor: context.stageStyle.canvasColor,
+                            onColorChanged: onSurfaceColorChanged,
+                          ),
+                        ),
+                      );
+                    },
                   );
                 },
-                context: context,
-              );
-            },
-          ),
-          // toggle light and dark mode
-          IconButton(
-            icon: Icon(
-              Theme.of(context).brightness == Brightness.light ? Icons.light_mode : Icons.dark_mode,
-              color: Colors.grey,
-            ),
-            onPressed: onStyleToggled,
-          ),
-          IconButton(
-            icon: Icon(Icons.aspect_ratio, color: settings.forceSize ? Colors.blue : Colors.grey),
-            onPressed: () {
-              onSettingsChanged(
-                settings.copyWith(
-                  forceSize: !settings.forceSize,
+              ),
+              // toggle light and dark mode
+              IconButton(
+                icon: Icon(
+                  Theme.of(context).brightness == Brightness.light ? Icons.light_mode : Icons.dark_mode,
+                  color: Colors.grey,
                 ),
-              );
-            },
-          ),
-          IconButton(
-            onPressed: () {
-              onSettingsChanged(
-                settings.copyWith(
-                  showCrossHair: !settings.showCrossHair,
+                onPressed: onStyleToggled,
+              ),
+              IconButton(
+                icon: Icon(Icons.aspect_ratio, color: canvasController.forceSize ? Colors.blue : Colors.grey),
+                onPressed: () {
+                  canvasController.forceSize = !canvasController.forceSize;
+                },
+              ),
+              IconButton(
+                icon: Icon(
+                  Icons.center_focus_strong_outlined,
+                  color: canvasController.showCrossHair ? Colors.blue : Colors.grey,
                 ),
-              );
-            },
-            icon: Icon(
-              Icons.center_focus_strong_outlined,
-              color: settings.showCrossHair ? Colors.blue : Colors.grey,
-            ),
+                onPressed: () {
+                  canvasController.showCrossHair = !canvasController.showCrossHair;
+                },
+              ),
+            ],
           ),
-        ],
+        );
+      },
+    );
+  }
+}
+
+/// A settings bar that allows the user to toggle and adjust various stage settings.
+class SettingsBarRight extends StatelessWidget {
+  /// Creates a new settings bar.
+  const SettingsBarRight({
+    super.key,
+    required this.canvasController,
+  });
+
+  /// The canvas controller to manipulate the stage.
+  final StageCanvasController canvasController;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: canvasController,
+      builder: (BuildContext context, Widget? child) {
+        return Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.grey.withOpacity(0.3),
+              width: 2,
+            ),
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(64),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: SizedBox(
+                  height: 24,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.text_fields,
+                            color: canvasController.textScale == 1.5 ? Colors.blue : Colors.grey,
+                            size: 16,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${canvasController.textScale.toStringWithOptionalDecimal(2)}x',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: canvasController.textScale == 1.5 ? Colors.blue : Colors.grey,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 10,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (context) {
+                      return SimpleDialog(
+                        title: const Text('Text Scale'),
+                        children: [
+                          ListenableBuilder(
+                            listenable: canvasController,
+                            builder: (context, _) {
+                              return Container(
+                                constraints: const BoxConstraints(minWidth: 400, maxWidth: 400),
+                                padding: const EdgeInsets.all(16),
+                                child: Column(
+                                  children: [
+                                    const Text(
+                                      'One-third of users modify text sizes for better readability. '
+                                      'Developers should avoid using fixed heights for text to prevent content from being cut off when font sizes are increased.'
+                                      '\n'
+                                      'Supporting dynamic text scaling ensures applications are inclusive, user-friendly, and compliant with accessibility standards.',
+                                    ),
+                                    const SizedBox(height: 16),
+                                    Row(
+                                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                                      children: [
+                                        Text(
+                                          'textScaleFactor: ${canvasController.textScale.toStringAsFixed(2)}x',
+                                          style: const TextStyle(
+                                            fontFeatures: [FontFeature.tabularFigures()],
+                                            // mono space font
+                                            fontFamily: 'Roboto Mono',
+                                            fontSize: 14,
+                                          ),
+                                        ),
+                                        ElevatedButton(
+                                          onPressed: () {
+                                            canvasController.textScale = 1.0;
+                                          },
+                                          child: const Text('Reset'),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 16),
+                                    Slider(
+                                      value: canvasController.textScale,
+                                      onChanged: (value) {
+                                        canvasController.textScale = value;
+                                      },
+                                      min: 0.5,
+                                      max: 3.0,
+                                      divisions: 15,
+                                    ),
+                                    const SizedBox(height: 4),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+              ),
+              const HorizontalDivider(),
+              Container(
+                height: 24,
+                padding: const EdgeInsets.only(right: 10),
+                width: 84,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${canvasController.zoomFactor.toStringAsFixed(2)}x',
+                        textAlign: TextAlign.right,
+                        style: const TextStyle(
+                          color: Colors.grey,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 10,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      const Icon(
+                        Icons.zoom_in,
+                        color: Colors.grey,
+                        size: 16,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// A horizontal divider
+class HorizontalDivider extends StatelessWidget {
+  /// Like [Divider] but horizontal.
+  const HorizontalDivider({
+    super.key,
+    this.height,
+  });
+
+  final double? height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height ?? 20,
+      child: const RotatedBox(
+        quarterTurns: 1,
+        child: Divider(
+          height: 1,
+        ),
       ),
     );
+  }
+}
+
+extension on double {
+  /// Removes all trailing zeros from a double and keeps up to [decimalPlaces] decimal places.
+  /// 1.0 -> 1
+  /// 1.020 -> 1.02
+  String toStringWithOptionalDecimal(int decimalPlaces) {
+    return toStringAsFixed(decimalPlaces).replaceAll(RegExp(r'0*$'), '').replaceAll(RegExp(r'\.$'), '');
   }
 }


### PR DESCRIPTION
![Screen-Recording-2024-07-30-19-51-20 gif](https://github.com/user-attachments/assets/67cf3c52-98d6-434a-a87a-5ab3a6852fc2)

Added a new textScaleFactor adjustment tool to easily test different scale factors. I combined it with the stage zoom.

> One-third of users modify text sizes for better readability. Developers should avoid using fixed heights for text to prevent content from being cut off when font sizes are increased. Supporting dynamic text scaling ensures applications are inclusive, user-friendly, and compliant with accessibility standards.

The textScale steps are arbitrarily chosen. There is a sheet at with the [exact number for iOS 15](https://docs.google.com/spreadsheets/d/1juRBR0TFnutI1Wc8zbMLSYNgazMSFE30cFcmhq6GXNs/edit?gid=0#gid=0 ). But they changed, so did the number of steps. Android has others, too. In the end any widget should be capable to support the range of `0.5-3x`. The exact details don't matter.


Implementation details:
- I created `StageCanvasController` (`ChangeNotifier`) instead of `StageSettings`
- I fixed the control bar arrow location using a `CompositedTransformFollower`
- I tried to make the zoom control interactive, too. But I failed miserably to change the zoom level of the `InteractiveWidget`. 

